### PR TITLE
relays per session + rewards UX improvements

### DIFF
--- a/ui/src/components/MonthlyRewards.tsx
+++ b/ui/src/components/MonthlyRewards.tsx
@@ -109,10 +109,27 @@ export const MonthlyRewards = (props: MonthlyRewardsProps) => {
                             <AccordionButton>
                                 <Box flex='1'>
                                     <HStack pt={1} pb={1}>
-                                        <Box pl={[1,8]} w={["200px", "200px"]} textAlign='left'>{monthNames[month.month]} {month.year}</Box>
-                                        <Spacer/>
-                                        { !isMobile && (<Box flexGrow={1} textAlign={"right"}>{Number(month.num_relays).toLocaleString()} relays</Box>) }
-                                        <Box pr={[2,8]} flexGrow={1} textAlign='right'>
+                                        <Box pl={[1,8]} w={["200px", "40%"]} textAlign='left'>{monthNames[month.month]} {month.year}</Box>
+                                        {/*<Spacer/>*/}
+                                        { !isMobile && (
+                                            <>
+                                                <Box
+                                                    fontFamily={"Roboto Mono, mono"}
+                                                    fontSize={"sm"}
+                                                    w={"15%"} flexGrow={1} textAlign={"right"}>
+                                                    {month.num_relays.toLocaleString()} <Text d={"inline"} fontSize="xs" textTransform={"uppercase"}> relays</Text>
+                                                </Box>
+                                                <Box fontFamily={"Roboto Mono, mono"} fontSize={"sm"} w={"15%"} flexGrow={1} textAlign={"right"}>
+                                                    {month.transactions.length.toLocaleString()}
+                                                    <Text d={"inline"} fontSize="xs" textTransform={"uppercase"}> sessions</Text>
+                                                </Box>
+                                                <Box fontFamily={"Roboto Mono, mono"} fontSize={"sm"} w={"15%"} flexGrow={1} textAlign={"right"}>
+                                                    {((month.num_relays/month.transactions.length) * 0.0089).toFixed(2)}
+                                                    <Text d={"inline"} fontSize="xs" textTransform={"uppercase"}> pokt/sess</Text>
+                                                </Box>
+                                            </>
+                                        ) }
+                                        <Box fontFamily={"Roboto Mono, mono"} fontSize={"sm"} minW={["150px", "15%"]} pr={[2,8]} flexGrow={1} textAlign='right'>
                                             {month.pokt_amount} <Text d="inline" fontSize={"xs"} textTransform={"uppercase"}>pokt</Text>
                                         </Box>
                                     </HStack>

--- a/ui/src/components/NodeMetrics.tsx
+++ b/ui/src/components/NodeMetrics.tsx
@@ -11,7 +11,12 @@ import {
 import React, {useEffect, useRef, useState} from "react";
 import {CryptoNode} from "../types/crypto-node";
 import {MonthlyReward, monthNames} from "../types/monthly-reward";
-import {EVENT_TOGGLE_LIFETIME_AVG, EVENT_TOGGLE_LIFETIME_AVG_PER_SESS, trackGoal} from "../events";
+import {
+    EVENT_TOGGLE_LIFETIME_AVG,
+    EVENT_TOGGLE_LIFETIME_AVG_PER_SESS,
+    EVENT_TOGGLE_TEN_THIRTY_NINETY,
+    trackGoal
+} from "../events";
 
 interface AppStatusProps {
     rewards: MonthlyReward[],
@@ -34,6 +39,7 @@ export const NodeMetrics = (props: AppStatusProps) => {
     const statBorderColor = useColorModeValue('gray.50', 'gray.50');
     const { isOpen: showAllTime, onToggle: toggleShowAllTime } = useDisclosure({ defaultIsOpen: true });
     const { isOpen: showAllTimePerSess, onToggle: toggleShowAllTimePerSess } = useDisclosure({ defaultIsOpen: true })
+    const [tenThirtyNinetyState, setTenThirtyNinetyState] = useState(0);
 
     const emptyTimeUnits: TimeUnits = { units: '---', value: -1 }
     const [timeBetweenRewardsLatest, setTimeBetweenRewardsLatest] = useState(emptyTimeUnits);
@@ -188,26 +194,37 @@ export const NodeMetrics = (props: AppStatusProps) => {
                             <StatHelpText>{sortedByChain[0]?.num_relays?.toLocaleString()} relays</StatHelpText>
                         </Stat>
                     </Box>
-                    <Box  p={5} minWidth={"185px"}>
-                        <Stat align={"center"}>
-                            <StatLabel>10 Day Average</StatLabel>
-                            <StatNumber>{avgPoktForLastDays(10)}</StatNumber>
-                            <StatHelpText>POKT per day</StatHelpText>
-                        </Stat>
-                    </Box>
-                    <Box borderWidth={1} borderRadius={20} p={5} minWidth={"185px"} borderColor={"gray.50"}>
-                        <Stat align={"center"}>
-                            <StatLabel>30 Day Average</StatLabel>
-                            <StatNumber>{avgPoktForLastDays(30)}</StatNumber>
-                            <StatHelpText>POKT per day</StatHelpText>
-                        </Stat>
-                    </Box>
-                    <Box  p={5} minWidth={"185px"}>
-                        <Stat align={"center"}>
-                            <StatLabel>90 Day Average</StatLabel>
-                            <StatNumber>{avgPoktForLastDays(90)}</StatNumber>
-                            <StatHelpText>POKT per day</StatHelpText>
-                        </Stat>
+                    <Box p={5} minWidth={"185px"}
+                         _hover={ {color: statHoverColor} }
+                         cursor={'pointer'}
+                         onClick={() => {
+                             const newState = tenThirtyNinetyState + 1;
+                             setTenThirtyNinetyState(newState > 2 ? 0 : newState);
+                             trackGoal(EVENT_TOGGLE_TEN_THIRTY_NINETY);
+                        }}
+                    >
+                        {tenThirtyNinetyState === 0 && (
+                            <Stat align={"center"}>
+                                <StatLabel>10 Day Average</StatLabel>
+                                <StatNumber>{avgPoktForLastDays(10)}</StatNumber>
+                                <StatHelpText>POKT per day</StatHelpText>
+                            </Stat>
+                        )}
+                        {tenThirtyNinetyState === 1 && (
+                            <Stat align={"center"}>
+                                <StatLabel>30 Day Average</StatLabel>
+                                <StatNumber>{avgPoktForLastDays(30)}</StatNumber>
+                                <StatHelpText>POKT per day</StatHelpText>
+                            </Stat>
+                        )}
+                        {tenThirtyNinetyState === 2 && (
+                            <Stat align={"center"}>
+                                <StatLabel>90 Day Average</StatLabel>
+                                <StatNumber>{avgPoktForLastDays(90)}</StatNumber>
+                                <StatHelpText>POKT per day</StatHelpText>
+                            </Stat>
+                        )}
+
                     </Box>
                     <Box  p={5} minWidth={"185px"} borderWidth={1} borderRadius={20} borderColor={"gray.50"}>
                         <Stat align={"center"}>

--- a/ui/src/components/NodeMetrics.tsx
+++ b/ui/src/components/NodeMetrics.tsx
@@ -11,7 +11,7 @@ import {
 import React, {useEffect, useRef, useState} from "react";
 import {CryptoNode} from "../types/crypto-node";
 import {MonthlyReward, monthNames} from "../types/monthly-reward";
-import {EVENT_TOGGLE_LIFETIME_AVG, trackGoal} from "../events";
+import {EVENT_TOGGLE_LIFETIME_AVG, EVENT_TOGGLE_LIFETIME_AVG_PER_SESS, trackGoal} from "../events";
 
 interface AppStatusProps {
     rewards: MonthlyReward[],
@@ -265,7 +265,7 @@ export const NodeMetrics = (props: AppStatusProps) => {
                     <Box p={5} minWidth={"185px"}
                          cursor={'pointer'}
                          onClick={() => {
-                             // trackGoal(EVENT_TOGGLE_LIFETIME_AVG);
+                             trackGoal(EVENT_TOGGLE_LIFETIME_AVG_PER_SESS);
                              toggleShowAllTimePerSess();
                          }}
                     >

--- a/ui/src/components/NodeMetrics.tsx
+++ b/ui/src/components/NodeMetrics.tsx
@@ -33,12 +33,16 @@ export const NodeMetrics = (props: AppStatusProps) => {
     const statHoverColor = useColorModeValue('cyan.800', 'blue.100');
     const statBorderColor = useColorModeValue('gray.50', 'gray.50');
     const { isOpen: showAllTime, onToggle: toggleShowAllTime } = useDisclosure({ defaultIsOpen: true });
+    const { isOpen: showAllTimePerSess, onToggle: toggleShowAllTimePerSess } = useDisclosure({ defaultIsOpen: true })
 
     const emptyTimeUnits: TimeUnits = { units: '---', value: -1 }
     const [timeBetweenRewardsLatest, setTimeBetweenRewardsLatest] = useState(emptyTimeUnits);
     const [timeBetweenRewardsAllTime, setTimeBetweenRewardsAllTime] = useState(emptyTimeUnits);
     const [timeSinceReward, setTimeSinceReward] = useState(emptyTimeUnits);
+    const [avgPoktPerSessionLatestMonth, setAvgPoktPerSessionLatestMonth] = useState(0);
+    const [avgPoktPerSession, setAvgPoktPerSession] = useState(0);
     const [latestMonthName, setLatestMonthName] = useState('');
+
 
     const scrollRef = useRef(null);
 
@@ -53,12 +57,16 @@ export const NodeMetrics = (props: AppStatusProps) => {
         }
 
         let total = 0;
+        let lifetimeNumRelays = 0;
+        let lifetimeNumSessions = 0;
         props.rewards.map((r) => {
             r.transactions.map((t) => {
                 const txDate = new Date(t.time);
                 if((txDate.getTime() >= pastDate.getTime()) && t.is_confirmed) {
                     total += t.num_proofs;
                 }
+                lifetimeNumRelays += t.num_proofs;
+                lifetimeNumSessions++;
                 return this;
             });
             return this;
@@ -101,15 +109,11 @@ export const NodeMetrics = (props: AppStatusProps) => {
         };
     }
 
-
-
     const sortedRewards = props.rewards;
     const sortedByChain = (sortedRewards[0] !== undefined) ?
         sortedRewards[0].relays_by_chain.sort((a, b) => {
             return (a.num_relays > b.num_relays) ? -1 : 1;
         }) : [];
-
-
 
     useEffect(() => {
 
@@ -133,10 +137,25 @@ export const NodeMetrics = (props: AppStatusProps) => {
             }
         }
 
+        let lifetimeNumRelays = 0;
+        let lifetimeNumSessions = 0;
+        props.rewards.map((r) => {
+            r.transactions.map((t) => {
+                lifetimeNumRelays += t.num_proofs;
+                lifetimeNumSessions++;
+                return this;
+            });
+            return this;
+        });
+        setAvgPoktPerSession((lifetimeNumRelays/lifetimeNumSessions) * 0.0089);
+
         const latestMonth = sortedRewards[0]?.month;
         const lastRewardDate = latestTxTime();
         setTimeBetweenRewardsLatest(timeUnits(sortedRewards[0]?.avg_sec_between_rewards ?? -1));
         setLatestMonthName(latestMonth ? monthNames[latestMonth] : '---');
+        if(latestMonth) {
+            setAvgPoktPerSessionLatestMonth((sortedRewards[0].num_relays / sortedRewards[0].transactions.length) * 0.0089);
+        }
 
         if(lastRewardDate) {
             setTimeSinceReward(timeSince(lastRewardDate));
@@ -153,8 +172,6 @@ export const NodeMetrics = (props: AppStatusProps) => {
 
     }, [props, sortedRewards]);
 
-
-
     return(
         <>
             <Box mt={8} mb={8} ml={'auto'} mr={'auto'} p={0} pl={4} pr={4} w={["100%", 'unset']} h={"100%"}
@@ -164,87 +181,115 @@ export const NodeMetrics = (props: AppStatusProps) => {
                 {/*{!isMobile && (*/}
                 {/*    <HorizontalScroll reverseScroll={true} animValues={15} pageLock={true}>*/}
                 <HStack>
-                        <Box  p={5} minWidth={"185px"} borderWidth={1} borderRadius={20} borderColor={"gray.50"}>
-                            <Stat align={"center"}>
-                                <StatLabel>Top Chain This Month</StatLabel>
-                                <StatNumber>{sortedByChain[0]?.name}</StatNumber>
-                                <StatHelpText>{sortedByChain[0]?.num_relays?.toLocaleString()} relays</StatHelpText>
-                            </Stat>
-                        </Box>
-                        <Box  p={5} minWidth={"185px"}>
-                            <Stat align={"center"}>
-                                <StatLabel>10 Day Average</StatLabel>
-                                <StatNumber>{avgPoktForLastDays(10)}</StatNumber>
-                                <StatHelpText>POKT per day</StatHelpText>
-                            </Stat>
-                        </Box>
-                        <Box borderWidth={1} borderRadius={20} p={5} minWidth={"185px"} borderColor={"gray.50"}>
-                            <Stat align={"center"}>
-                                <StatLabel>30 Day Average</StatLabel>
-                                <StatNumber>{avgPoktForLastDays(30)}</StatNumber>
-                                <StatHelpText>POKT per day</StatHelpText>
-                            </Stat>
-                        </Box>
-                        <Box  p={5} minWidth={"185px"}>
-                            <Stat align={"center"}>
-                                <StatLabel>90 Day Average</StatLabel>
-                                <StatNumber>{avgPoktForLastDays(90)}</StatNumber>
-                                <StatHelpText>POKT per day</StatHelpText>
-                            </Stat>
-                        </Box>
-                        <Box  p={5} minWidth={"185px"} borderWidth={1} borderRadius={20} borderColor={"gray.50"}>
-                            <Stat align={"center"}>
-                                <StatLabel>Last 24 hrs</StatLabel>
-                                <StatNumber>{avgPoktForLastDays(1) ?? 0}</StatNumber>
-                                <StatHelpText>POKT earned</StatHelpText>
-                            </Stat>
-                        </Box>
-                        <Box  p={5} minWidth={"185px"}>
-                            <Stat align={"center"}>
-                                <StatLabel>Last reward</StatLabel>
-                                <StatNumber>{timeSinceReward.value > 0 ? timeSinceReward.value : '--'}</StatNumber>
-                                <StatHelpText>{timeSinceReward.units} ago</StatHelpText>
-                            </Stat>
-                        </Box>
-                        <Box p={5} minWidth={"185px"} borderWidth={1} borderRadius={20}
-                             borderColor={statBorderColor}
-                             _hover={ {borderColor: statHoverColor} }
-                             cursor={'pointer'}
-                             onClick={() => {
-                                 trackGoal(EVENT_TOGGLE_LIFETIME_AVG);
-                                 toggleShowAllTime();
-                             }}
-                        >
-                            <Stat _hover={ {color: statHoverColor} } align={"center"}>
-                                <StatLabel>
-                                    {showAllTime ?
-                                        (<>Lifetime Avg</>) :
-                                        (<>{timeBetweenRewardsLatest.value < 0 ? '---' : latestMonthName} Avg</>)
+                    <Box  p={5} minWidth={"185px"} borderWidth={1} borderRadius={20} borderColor={"gray.50"}>
+                        <Stat align={"center"}>
+                            <StatLabel>Top Chain This Month</StatLabel>
+                            <StatNumber>{sortedByChain[0]?.name}</StatNumber>
+                            <StatHelpText>{sortedByChain[0]?.num_relays?.toLocaleString()} relays</StatHelpText>
+                        </Stat>
+                    </Box>
+                    <Box  p={5} minWidth={"185px"}>
+                        <Stat align={"center"}>
+                            <StatLabel>10 Day Average</StatLabel>
+                            <StatNumber>{avgPoktForLastDays(10)}</StatNumber>
+                            <StatHelpText>POKT per day</StatHelpText>
+                        </Stat>
+                    </Box>
+                    <Box borderWidth={1} borderRadius={20} p={5} minWidth={"185px"} borderColor={"gray.50"}>
+                        <Stat align={"center"}>
+                            <StatLabel>30 Day Average</StatLabel>
+                            <StatNumber>{avgPoktForLastDays(30)}</StatNumber>
+                            <StatHelpText>POKT per day</StatHelpText>
+                        </Stat>
+                    </Box>
+                    <Box  p={5} minWidth={"185px"}>
+                        <Stat align={"center"}>
+                            <StatLabel>90 Day Average</StatLabel>
+                            <StatNumber>{avgPoktForLastDays(90)}</StatNumber>
+                            <StatHelpText>POKT per day</StatHelpText>
+                        </Stat>
+                    </Box>
+                    <Box  p={5} minWidth={"185px"} borderWidth={1} borderRadius={20} borderColor={"gray.50"}>
+                        <Stat align={"center"}>
+                            <StatLabel>Last 24 hrs</StatLabel>
+                            <StatNumber>{avgPoktForLastDays(1) ?? 0}</StatNumber>
+                            <StatHelpText>POKT earned</StatHelpText>
+                        </Stat>
+                    </Box>
+                    <Box  p={5} minWidth={"185px"}>
+                        <Stat align={"center"}>
+                            <StatLabel>Last reward</StatLabel>
+                            <StatNumber>{timeSinceReward.value > 0 ? timeSinceReward.value : '--'}</StatNumber>
+                            <StatHelpText>{timeSinceReward.units} ago</StatHelpText>
+                        </Stat>
+                    </Box>
+                    <Box p={5} minWidth={"185px"} borderWidth={1} borderRadius={20}
+                         borderColor={statBorderColor}
+                         _hover={ {borderColor: statHoverColor} }
+                         cursor={'pointer'}
+                         onClick={() => {
+                             trackGoal(EVENT_TOGGLE_LIFETIME_AVG);
+                             toggleShowAllTime();
+                         }}
+                    >
+                        <Stat _hover={ {color: statHoverColor} } align={"center"}>
+                            <StatLabel>
+                                {showAllTime ?
+                                    (<>Lifetime Avg</>) :
+                                    (<>{timeBetweenRewardsLatest.value < 0 ? '---' : latestMonthName} Avg</>)
 
-                                    }
-                                </StatLabel>
-                                <StatNumber>
-                                    {showAllTime ?
-                                        (
-                                            <>
-                                                {timeBetweenRewardsAllTime.value && timeBetweenRewardsAllTime.value >= 0 ?
-                                                    `${timeBetweenRewardsAllTime.value.toString()} ${timeBetweenRewardsAllTime.units}` : '---'
-                                                }
-                                            </>
-                                        ) : (
-                                            <>
-                                                {timeBetweenRewardsLatest.value && timeBetweenRewardsAllTime.value >= 0 ?
-                                                    timeBetweenRewardsLatest.value.toString() : '--'
-                                                }
-                                                {timeBetweenRewardsLatest.units}
-                                            </>
-                                        )
-                                    }
+                                }
+                            </StatLabel>
+                            <StatNumber>
+                                {showAllTime ?
+                                    (
+                                        <>
+                                            {timeBetweenRewardsAllTime.value && timeBetweenRewardsAllTime.value >= 0 ?
+                                                `${timeBetweenRewardsAllTime.value.toString()} ${timeBetweenRewardsAllTime.units}` : '---'
+                                            }
+                                        </>
+                                    ) : (
+                                        <>
+                                            {timeBetweenRewardsLatest.value && timeBetweenRewardsAllTime.value >= 0 ?
+                                                timeBetweenRewardsLatest.value.toString() : '--'
+                                            }
+                                            {timeBetweenRewardsLatest.units}
+                                        </>
+                                    )
+                                }
 
-                                </StatNumber>
-                                <StatHelpText>between rewards</StatHelpText>
-                            </Stat>
-                        </Box>
+                            </StatNumber>
+                            <StatHelpText>between rewards</StatHelpText>
+                        </Stat>
+                    </Box>
+                    <Box p={5} minWidth={"185px"}
+                         cursor={'pointer'}
+                         onClick={() => {
+                             // trackGoal(EVENT_TOGGLE_LIFETIME_AVG);
+                             toggleShowAllTimePerSess();
+                         }}
+                    >
+                        <Stat _hover={ {color: statHoverColor} } align={"center"}>
+                            <StatLabel>
+                                {showAllTimePerSess ?
+                                    (<>Lifetime Avg</>) :
+                                    (<>{timeBetweenRewardsLatest.value < 0 ? '---' : latestMonthName} Avg</>)
+
+                                }
+                            </StatLabel>
+                            <StatNumber>
+                                {showAllTimePerSess ?
+                                    (
+                                        <>{avgPoktPerSession >= 0 ? avgPoktPerSession.toFixed(0) : '---'}</>
+                                    ) : (
+                                        <>{avgPoktPerSessionLatestMonth >= 0 ? avgPoktPerSessionLatestMonth.toFixed(0) : '---'}</>
+                                    )
+                                }
+
+                            </StatNumber>
+                            <StatHelpText>POKT per session</StatHelpText>
+                        </Stat>
+                    </Box>
                     {/*</HorizontalScroll>*/}
                 </HStack>
                 {/*)}*/}

--- a/ui/src/events.ts
+++ b/ui/src/events.ts
@@ -12,6 +12,7 @@ export const EVENT_MONTH_METRICS = '4GHGNFZZ';
 export const EVENT_TOGGLE_LIFETIME_AVG = 'CEOMNLN0';
 export const EVENT_TOGGLE_LIFETIME_AVG_PER_SESS = 'IENKUKJO';
 export const EVENT_TOGGLE_PENDING_UNITS = '0IVHB1EO';
+export const EVENT_TOGGLE_TEN_THIRTY_NINETY = 'ISKX5JUD';
 
 export const trackGoal = (eventCode: string) => {
     // @ts-ignore

--- a/ui/src/events.ts
+++ b/ui/src/events.ts
@@ -10,6 +10,7 @@ export const EVENT_MONTH_CLOSE='VJVXC7FD';
 export const EVENT_MONTH_TRANSACTIONS = 'HGSCZJOI';
 export const EVENT_MONTH_METRICS = '4GHGNFZZ';
 export const EVENT_TOGGLE_LIFETIME_AVG = 'CEOMNLN0';
+export const EVENT_TOGGLE_LIFETIME_AVG_PER_SESS = 'IENKUKJO';
 export const EVENT_TOGGLE_PENDING_UNITS = '0IVHB1EO';
 
 export const trackGoal = (eventCode: string) => {


### PR DESCRIPTION
Adds session count and relays per session. 
Text alignment and font adjustments in rewards tab / accordion.
Collapse 10/30/90 day stats into a toggle-stat