### PR TITLE
Fixes incorrect claim expiration

### DIFF
--- a/monitoring-service/monitoring/service.go
+++ b/monitoring-service/monitoring/service.go
@@ -106,6 +106,16 @@ func (s *Service) ParamsAtHeight(height int64) (pocket.Params, error) {
 	}
 	params.ProposerPercentage = uint8(pp)
 
+	claimExpirationBlocks, ok := allParams.PocketParams.Get("pocketcore/ClaimExpiration")
+	if !ok {
+		return pocket.Params{}, errors.New("ParamsAtHeight: node_params key not found 'pocketcore/ClaimExpiration'")
+	}
+	claimExpires, err := strconv.ParseUint(claimExpirationBlocks, 10, 64)
+	if err != nil {
+		return pocket.Params{}, fmt.Errorf("ParamsAtHeight: failed to parse node_params ket 'pocketcore/ClaimExpiration': %s", err)
+	}
+	params.ClaimExpirationBlocks = uint(claimExpires)
+
 	return params, nil
 }
 
@@ -128,6 +138,7 @@ func (s *Service) AccountTransactions(address string, page uint, perPage uint, s
 			return nil, fmt.Errorf("AccountTransactions: %s", err)
 		}
 
+		tx.ExpireHeight = params.ClaimExpirationBlocks + tx.Height
 		transactions[i] = tx
 	}
 

--- a/monitoring-service/pocket/params.go
+++ b/monitoring-service/pocket/params.go
@@ -4,6 +4,7 @@ type Params struct {
 	RelaysToTokensMultiplier float64
 	DaoAllocation            uint8
 	ProposerPercentage       uint8
+	ClaimExpirationBlocks    uint
 }
 
 type AllParams struct {

--- a/monitoring-service/provider/pocket/transaction.go
+++ b/monitoring-service/provider/pocket/transaction.go
@@ -72,7 +72,6 @@ func (t *transactionResponse) Transaction() (pocket.Transaction, error) {
 		}
 
 		tx.SessionHeight = uint(sessionHeight)
-		tx.ExpireHeight = uint(sessionHeight + ClaimExpirationBlocks)
 		tx.ChainID = t.StdTx.Message.Value.Header.Chain
 		tx.AppPubkey = t.StdTx.Message.Value.Header.AppPubKey
 		break

--- a/ui/src/components/MonthlyRewards.tsx
+++ b/ui/src/components/MonthlyRewards.tsx
@@ -23,7 +23,7 @@ import {NodeContext} from "../context";
 import {MonthlyReward, monthNames} from "../types/monthly-reward";
 import {RewardTransaction} from "./RewardTransaction";
 import {PieChart} from "./PieChart";
-import {getClaims} from "../MonitoringService";
+import {getClaims, getHeight} from "../MonitoringService";
 import {EVENT_MONTH_CLOSE, EVENT_MONTH_METRICS, EVENT_MONTH_OPEN, EVENT_MONTH_TRANSACTIONS, trackGoal} from "../events";
 import {DailyChart} from "./DailyChart";
 import {DailyChartStacked} from "./DailyChartStacked";
@@ -38,6 +38,7 @@ type MonthlyRewardsProps = {
 
 export const MonthlyRewards = (props: MonthlyRewardsProps) => {
     const [hasLoaded, setHasLoaded] = useState(false);
+    const [currentHeight, setCurrentHeight] = useState(0)
 
     const node = useContext(NodeContext)
     const isMobile = useBreakpointValue([true, false]);
@@ -45,6 +46,11 @@ export const MonthlyRewards = (props: MonthlyRewardsProps) => {
 
     const getRewards = useCallback(() => {
         props.setIsRefreshing(true);
+
+        getHeight()
+            .then((h) => setCurrentHeight(h))
+            .catch((err) => { console.error("ERROR", err); });
+
         getClaims(node.address).then((months) => {
             props.onRewardsLoaded(months);
         }).catch((err) => {
@@ -243,7 +249,12 @@ export const MonthlyRewards = (props: MonthlyRewardsProps) => {
                                             {month.transactions.slice(0).reverse().map((tx, j) => {
                                                 const rowColor = (j % 2 === 0) ? bgEven : bgOdd;
                                                 return (
-                                                    <RewardTransaction key={tx.hash} tx={tx} color={rowColor}/>
+                                                    <RewardTransaction
+                                                        currentHeight={currentHeight}
+                                                        key={tx.hash}
+                                                        tx={tx}
+                                                        color={rowColor}
+                                                    />
                                                 )
                                             })}
                                         </Grid>

--- a/ui/src/components/RewardTransaction.tsx
+++ b/ui/src/components/RewardTransaction.tsx
@@ -1,11 +1,14 @@
 import {Transaction} from "../types/transaction";
 import {Box, GridItem, IconButton, Text, useBreakpointValue, useClipboard} from "@chakra-ui/react";
 import {CheckCircleIcon, CheckIcon, CopyIcon, TimeIcon} from "@chakra-ui/icons";
-import React from 'react';
+import React, {useContext} from 'react';
+import {NodeContext} from "../context";
+import {BiError, BiErrorAlt, BiErrorCircle, BiMessageError, GiTerror, MdError} from "react-icons/all";
 
 interface RewardTransactionProps {
     tx: Transaction,
     color: string,
+    currentHeight: number
 }
 
 export const RewardTransaction = (props: RewardTransactionProps) => {
@@ -16,6 +19,7 @@ export const RewardTransaction = (props: RewardTransactionProps) => {
     const {hasCopied: pubkeyHasCopied, onCopy: pubkeyCopy} = useClipboard(tx.app_pubkey);
     const time = new Date(tx.time);
     const isMobile = useBreakpointValue([true, false]);
+    const node = useContext(NodeContext)
 
     return (
         <React.Fragment key={tx.hash}>
@@ -60,6 +64,17 @@ export const RewardTransaction = (props: RewardTransactionProps) => {
                             title={`confirmed for session height ${tx.session_height}`}
                             icon={(<CheckCircleIcon color="green.400"/>)}
                         />
+                    ) : (tx.expire_height <= props.currentHeight) ? (
+                        <IconButton
+                            variant="ghost"
+                            boxShadow={0}
+                            _focus={{boxShadow: "none"}}
+                            _hover={{}}
+                            cursor={"default"}
+                            aria-label="expired"
+                            title={`claim expired at block ${tx.expire_height}`}
+                            icon={(<MdError style={{color: "#FF0000"}} />)}
+                        />
                     ) : (
                         <IconButton
                             variant="ghost"
@@ -68,7 +83,7 @@ export const RewardTransaction = (props: RewardTransactionProps) => {
                             _hover={{}}
                             cursor={"default"}
                             aria-label="unconfirmed"
-                            title={`unconfirmed, expires at block ${tx.expire_height}`}
+                            title={`unconfirmed as of ${props.currentHeight}, expires at block ${tx.expire_height}`}
                             icon={(<TimeIcon  color="yellow.400"/>)}
                         />
                     )

--- a/ui/src/components/RewardTransaction.tsx
+++ b/ui/src/components/RewardTransaction.tsx
@@ -1,9 +1,8 @@
 import {Transaction} from "../types/transaction";
 import {Box, GridItem, IconButton, Text, useBreakpointValue, useClipboard} from "@chakra-ui/react";
 import {CheckCircleIcon, CheckIcon, CopyIcon, TimeIcon} from "@chakra-ui/icons";
-import React, {useContext} from 'react';
-import {NodeContext} from "../context";
-import {BiError, BiErrorAlt, BiErrorCircle, BiMessageError, GiTerror, MdError} from "react-icons/all";
+import React from 'react';
+import {MdError} from "react-icons/all";
 
 interface RewardTransactionProps {
     tx: Transaction,
@@ -13,13 +12,11 @@ interface RewardTransactionProps {
 
 export const RewardTransaction = (props: RewardTransactionProps) => {
     const tx = props.tx;
-    const numProofs = tx.num_relays;
     const amount = (tx.type === 'pocketcore/proof') ? '-' : Number(tx.num_relays * tx.pokt_per_relay).toFixed(4) + " POKT";
     const {hasCopied, onCopy} = useClipboard(tx.hash);
     const {hasCopied: pubkeyHasCopied, onCopy: pubkeyCopy} = useClipboard(tx.app_pubkey);
     const time = new Date(tx.time);
     const isMobile = useBreakpointValue([true, false]);
-    const node = useContext(NodeContext)
 
     return (
         <React.Fragment key={tx.hash}>


### PR DESCRIPTION
Current implementation hard-codes (incorrect) claim expiration parameter as 120 blocks.  This update uses the on-chain parameter `pocketcore/ClaimExpiration`, along with a UI update to help identify when claims have expired.